### PR TITLE
Bump node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   kube-version:
     description: Kube version used to download kubectl executable, defaults to latest
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   color: blue


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/